### PR TITLE
update to newer tensorflow versions

### DIFF
--- a/dbn/tensorflow/models.py
+++ b/dbn/tensorflow/models.py
@@ -427,7 +427,7 @@ class SupervisedDBNClassification(TensorFlowAbstractSupervisedDBN, ClassifierMix
     def _build_model(self, weights=None):
         super(SupervisedDBNClassification, self)._build_model(weights)
         self.output = tf.nn.softmax(self.y)
-        self.cost_function = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=self.y, labels=self.y_))
+        self.cost_function = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(logits=self.y, labels=tf.stop_gradient(self.y_)))
         self.train_step = self.optimizer.minimize(self.cost_function)
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.12.0
-scipy==0.18.1
-scikit-learn==0.18.1
-tensorflow==1.0.0
+numpy>=1.12.0
+scipy>=0.18.1
+scikit-learn>=0.18.1
+tensorflow>=1.5.0


### PR DESCRIPTION
Removes following warning.
```
WARNING:tensorflow:From <python script>: softmax_cross_entropy_with_logits (from tensorflow.python.ops.nn_ops) is deprecated and will be removed in a future version.
Instructions for updating:

Future major versions of TensorFlow will allow gradients to flow
into the labels input on backprop by default.

See tf.nn.softmax_cross_entropy_with_logits_v2.
```